### PR TITLE
[Backport] Fixed minicart cancel button area overlapping issue

### DIFF
--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -166,6 +166,7 @@
                     @_icon-font-line-height: 16px,
                     @_icon-font-text-hide: true
                 );
+                margin: 10px;
             }
 
             &.showcart {

--- a/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
+++ b/app/design/frontend/Magento/luma/Magento_Checkout/web/css/source/module/_minicart.less
@@ -153,20 +153,19 @@
 
         .action {
             &.close {
-                height: 40px;
+                height: 30px;
                 position: absolute;
                 right: 0;
                 top: 0;
-                width: 40px;
+                width: 25px;
                 .lib-button-reset();
                 .lib-button-icon(
                     @icon-remove,
                     @_icon-font-color: @minicart-icons-color,
-                    @_icon-font-size: 16px,
-                    @_icon-font-line-height: 16px,
+                    @_icon-font-size: 14px,
+                    @_icon-font-line-height: 14px,
                     @_icon-font-text-hide: true
                 );
-                margin: 10px;
             }
 
             &.showcart {


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19839
<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->
Fixed minicart cancel button area overlapping issue on v2.3
<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
1. magento/magento2#19836: Minicart cancel button area overlapping to cart subtotal label


### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Step 1: Go to base url (frontend)
Step 2: add any product in cart fron catagory page aor any sigle product
Step 3: click to minicart icon in header
Step 4: Move mouse over the close button
![2018-12-17_14-48-04](https://user-images.githubusercontent.com/12389799/50077811-74dc4800-020b-11e9-8be8-050d093ecd12.jpg)


### Contribution checklist (*)
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
