### PR TITLE
[Backport] min php version fix

### DIFF
--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -13,7 +13,7 @@ error_reporting(E_ALL);
 /* PHP version validation */
 if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70103) {
     if (PHP_SAPI == 'cli') {
-        echo 'Magento supports 7.1.3 or later. ' .
+        echo 'Magento supports PHP 7.1.3 or later. ' .
             'Please read https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html';
     } else {
         echo <<<HTML

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -14,12 +14,12 @@ error_reporting(E_ALL);
 if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70103) {
     if (PHP_SAPI == 'cli') {
         echo 'Magento supports 7.1.3 or later. ' .
-            'Please read https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html';
+            'Please read https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html';
     } else {
         echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">
     <p>Magento supports PHP 7.1.3 or later. Please read
-    <a target="_blank" href="https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html">
+    <a target="_blank" href="https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html">
     Magento System Requirements</a>.
 </div>
 HTML;

--- a/app/bootstrap.php
+++ b/app/bootstrap.php
@@ -11,15 +11,15 @@ error_reporting(E_ALL);
 #ini_set('display_errors', 1);
 
 /* PHP version validation */
-if (!defined('PHP_VERSION_ID') || !(PHP_VERSION_ID === 70002 || PHP_VERSION_ID === 70004 || PHP_VERSION_ID >= 70006)) {
+if (!defined('PHP_VERSION_ID') || PHP_VERSION_ID < 70103) {
     if (PHP_SAPI == 'cli') {
-        echo 'Magento supports 7.0.2, 7.0.4, and 7.0.6 or later. ' .
-            'Please read http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html';
+        echo 'Magento supports 7.1.3 or later. ' .
+            'Please read https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html';
     } else {
         echo <<<HTML
 <div style="font:12px/1.35em arial, helvetica, sans-serif;">
-    <p>Magento supports PHP 7.0.2, 7.0.4, and 7.0.6 or later. Please read
-    <a target="_blank" href="http://devdocs.magento.com/guides/v2.2/install-gde/system-requirements.html">
+    <p>Magento supports PHP 7.1.3 or later. Please read
+    <a target="_blank" href="https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements2.html">
     Magento System Requirements</a>.
 </div>
 HTML;


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19455
Just a small update for the minimum PHP version and the link to the documentation

### Description (*)

as written here: https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html the min php version is 7.1.3 but the check in this file was wrong (so also the error messages)

### Fixed Issues (if relevant)
1. https://github.com/magento/magento2/issues/19453

### Manual testing scenarios (*)
1. try to run M2.3 on php5.5
2. the system tells you you should have php 7.0.something, which is wrong (as from https://devdocs.magento.com/guides/v2.3/install-gde/system-requirements-tech.html)
3. with this fix the minimum php version is checked correctly and the error message is also consistent