### PR TITLE
[Backport] 19085-Translation-in-tier-price-phtml-not-working

### DIFF
--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -15,7 +15,7 @@
                 + '</span>'
             + '</span>'; %>
         <li class="item">
-            <%= $t('<?= $block->escapeHtml(__('Buy %1 for %2 each and')) ?>').replace('%1', item.qty).replace('%2', priceStr) %>
+            <%= '<?= $block->escapeHtml(__('Buy %1 for %2 each and')) ?>'.replace('%1', item.qty).replace('%2', priceStr) %>
                 <strong class="benefit">
                     <?= $block->escapeHtml(__('save')) ?><span class="percent tier-<%= key %>">&nbsp;<%= item.percentage %></span>%
                 </strong>

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -15,10 +15,13 @@
                 + '</span>'
             + '</span>'; %>
         <li class="item">
-            <%= '<?= $block->escapeHtml(__('Buy %1 for %2 each and')) ?>'.replace('%1', item.qty).replace('%2', priceStr) %>
-                <strong class="benefit">
-                    <?= $block->escapeHtml(__('save')) ?><span class="percent tier-<%= key %>">&nbsp;<%= item.percentage %></span>%
-                </strong>
+            <%= '<?= $block->escapeHtml(__('Buy %1 for %2 each and', '%1', '%2')) ?>'
+            .replace('%1', item.qty)
+            .replace('%2', priceStr) %>
+            <strong class="benefit">
+                <?= $block->escapeHtml(__('save')) ?><span
+                        class="percent tier-<%= key %>">&nbsp;<%= item.percentage %></span>%
+            </strong>
         </li>
         <% }); %>
     </ul>

--- a/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
+++ b/app/code/Magento/ConfigurableProduct/view/base/templates/product/price/tier_price.phtml
@@ -15,9 +15,9 @@
                 + '</span>'
             + '</span>'; %>
         <li class="item">
-            <%= $t('Buy %1 for %2 each and').replace('%1', item.qty).replace('%2', priceStr) %>
+            <%= $t('<?= $block->escapeHtml(__('Buy %1 for %2 each and')) ?>').replace('%1', item.qty).replace('%2', priceStr) %>
                 <strong class="benefit">
-                        <%= $t('save') %><span class="percent tier-<%= key %>">&nbsp;<%= item.percentage %></span>%
+                    <?= $block->escapeHtml(__('save')) ?><span class="percent tier-<%= key %>">&nbsp;<%= item.percentage %></span>%
                 </strong>
         </li>
         <% }); %>


### PR DESCRIPTION
### Original Pull Request 
 https://github.com/magento/magento2/pull/19094
#19085:Translation in tier_price.phtml not working

### Description (#19085 )
provided fix uses PHP translate instead of not working JS translate

### Fixed Issues (if relevant)
1. magento/magento2#19085:Translation in tier_price.phtml not working 

### Manual testing scenarios (*)
1. Configure tier prices for configurable product (for his simples)
2. Change translates for phrases in Magento/ConfigurableProduct/i18n/en_US.csv:
"Buy %1 for %2 each and","Buy %1 for %2 each and"
save,save
3. Flush caches
4. Go to PDP
5. Choose option of configurable with tier prices
6. Check translates

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds on Travis CI are green)
